### PR TITLE
Rewrite last part of MultiHeadAttention.forward

### DIFF
--- a/nets/graph_encoder.py
+++ b/nets/graph_encoder.py
@@ -104,10 +104,9 @@ class MultiHeadAttention(nn.Module):
 
         heads = torch.matmul(attn, V)
 
-        out = torch.mm(
-            heads.permute(1, 2, 0, 3).contiguous().view(-1, self.n_heads * self.val_dim),
-            self.W_out.view(-1, self.embed_dim)
-        ).view(batch_size, n_query, self.embed_dim)
+        heads = heads.transpose(0, 1) # swap the dimensions for batch and heads to align it for the matmul
+        projected_heads = torch.matmul(heads, self.W_out)
+        out = torch.sum(projected_heads, dim=1) # sum across heads
 
         return out
 


### PR DESCRIPTION
It should be easier to understand now. I struggled understanding this part specifically because the matrix multiplication and summation from article are compressed into a single matrix multiplication. Now they are two separate steps.
I also tested the new MultiHeadAttention class with the following snippet to make sure nothing functional changed: 
```
batch_size = 3
n_query = 2
graph_size = 4
input_dim = 5

h = torch.normal(0, 0.5, [batch_size, graph_size, input_dim])
q = torch.normal(10., 1., [batch_size, n_query, input_dim])

torch.random.manual_seed(0)
attn = MultiHeadAttention(n_heads=6, input_dim=input_dim, key_dim=5, embed_dim=18)

torch.random.manual_seed(0)
attn_ref = MultiHeadAttentionRefactored(n_heads=6, input_dim=input_dim, key_dim=5, embed_dim=18)

out = attn.forward(q, h)
out_ref = attn_ref(q, h)

print(torch.allclose(out, out_ref))
```
Which prints True every time. (`MultiHeadAttentionRefactored` is the name I gave to the modified class)